### PR TITLE
Add multilanguage support

### DIFF
--- a/cmsplugin_articles_ai/admin.py
+++ b/cmsplugin_articles_ai/admin.py
@@ -16,12 +16,19 @@ class ArticleAttachmentInline(admin.StackedInline):
 
 
 class ArticleAdmin(PlaceholderAdminMixin, admin.ModelAdmin):
-    list_display = ("title", "author", "slug", "published_from", "published_until",)
+    list_display = (
+        "title",
+        "slug",
+        "language",
+        "author",
+        "published_from",
+        "published_until",
+    )
     prepopulated_fields = {
         "slug": ("title",),
     }
     filter_horizontal = ["tags"]
-    list_filter = ["tags"]
+    list_filter = ["language", "tags"]
     inlines = [ArticleAttachmentInline]
 
     def get_form(self, request, obj=None, **kwargs):

--- a/cmsplugin_articles_ai/cms_plugins.py
+++ b/cmsplugin_articles_ai/cms_plugins.py
@@ -12,10 +12,12 @@ class ArticleList(CMSPluginBase):
     module = _("Articles")
     name = _("List of latest articles")
     render_template = "cmsplugin_articles_ai/article_lift_list.html"
-    fields = ["article_amount"]
+    fields = ["article_amount", "language_filter"]
 
     def get_articles(self, plugin_conf):
-        return Article.objects.public()
+        return Article.objects.public(
+            language=plugin_conf.language_filter,
+        )
 
     def render(self, context, instance, placeholder):
         context.update({
@@ -30,7 +32,7 @@ class TagFilterArticleList(ArticleList):
     model = ArticleListPlugin
     name = _("Tag filtered article list")
     filter_horizontal = ["tags"]
-    fields = ["filter_mode", "tags", "article_amount"]
+    fields = ["filter_mode", "tags", "article_amount", "language_filter"]
 
     def get_articles(self, plugin_conf):
         articles = super(TagFilterArticleList, self).get_articles(plugin_conf)

--- a/cmsplugin_articles_ai/migrations/0002_add_language_fields.py
+++ b/cmsplugin_articles_ai/migrations/0002_add_language_fields.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+import softchoice.fields.language
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('cmsplugin_articles_ai', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='article',
+            name='language',
+            field=softchoice.fields.language.LanguageField(help_text='Leave this empty if you want the article to be shown regardless of any language filters.', blank=True, verbose_name='language', max_length=10),
+        ),
+        migrations.AddField(
+            model_name='articlelistplugin',
+            name='language_filter',
+            field=softchoice.fields.language.LanguageField(help_text="Select a language if you want to list only articles written in specificlanguage. If you don't select a language, the listing includes all languages.", blank=True, verbose_name='language filter', max_length=10),
+        ),
+    ]

--- a/cmsplugin_articles_ai/models/plugin_models.py
+++ b/cmsplugin_articles_ai/models/plugin_models.py
@@ -4,6 +4,7 @@ from django.db import models
 from django.utils.http import urlencode
 from django.utils.translation import ugettext_lazy as _
 from enumfields import Enum, EnumIntegerField
+from softchoice.fields.language import LanguageField
 
 from .tags import Tag
 
@@ -47,6 +48,15 @@ class ArticleListPlugin(CMSPlugin):
     article_amount = models.PositiveSmallIntegerField(
         default=5,
         verbose_name=_("amount of articles"),
+    )
+    language_filter = LanguageField(
+        verbose_name=_("language filter"),
+        default="",
+        blank=True,
+        help_text=_(
+            "Select a language if you want to list only articles written in specific"
+            "language. If you don't select a language, the listing includes all languages."
+        )
     )
 
     def __str__(self):

--- a/cmsplugin_articles_ai/views.py
+++ b/cmsplugin_articles_ai/views.py
@@ -37,7 +37,9 @@ class ArticleView(DetailView):
 class ArticleListView(ListView):
     """
     View for listing all public articles or a list of public articles
-    per tag. Lists are paginated according to settings value.
+    per tag. By default the list is language agnostic, but you can pass
+    optional language parameter to get a filtered list.
+    Lists are paginated according to settings value.
     """
     context_object_name = "articles"
     paginate_by = getattr(settings, "ARTICLES_PER_PAGE", 10)
@@ -46,10 +48,11 @@ class ArticleListView(ListView):
 
     def get(self, request, *args, **kwargs):
         self.tag_filter = self.kwargs.get("tag", "")
+        self.lang_filter = request.GET.get("lang", "")
         return super(ArticleListView, self).get(request, *args, **kwargs)
 
     def get_queryset(self):
-        articles = Article.objects.public()
+        articles = Article.objects.public(language=self.lang_filter)
         if self.tag_filter:
             return articles.filter(tags__name=self.tag_filter)
         return articles

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 django-cms>=3.2
 django-enumfields>=0.8.0
 django-filer>=1.2.4
+django-soft-choice-fields>=0.3.1
 djangocms_text_ckeditor>=3.0.0
 easy-thumbnails>=2.3

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -37,6 +37,28 @@ def test_article_list_plugin_article_count():
     assert len(context["articles"]) == 3
 
 
+@pytest.mark.django_db
+@pytest.mark.parametrize("language_filter", ["", "en", "fi"])
+def test_article_list_plugin_language_filter(language_filter):
+    """
+    Test article list plugin filters articles according to language filter
+    """
+    article_fi = PublicArticleFactory(language="fi")
+    article_en = PublicArticleFactory(language="en")
+    plugin = init_plugin(ArticleList, language_filter=language_filter)
+    plugin_instance = plugin.get_plugin_class_instance()
+    context = plugin_instance.render({}, plugin, None)
+    if language_filter == "en":
+        assert article_fi not in context["articles"]
+        assert article_en in context["articles"]
+    elif language_filter == "fi":
+        assert article_fi in context["articles"]
+        assert article_en not in context["articles"]
+    else:
+        assert article_fi in context["articles"]
+        assert article_en in context["articles"]
+
+
 @pytest.mark.urls("cmsplugin_articles_ai.article_urls")
 @pytest.mark.django_db
 @pytest.mark.parametrize("plugin_type", [

--- a/tests/test_querysets.py
+++ b/tests/test_querysets.py
@@ -45,16 +45,25 @@ def test_article_is_public():
 def test_article_public_query():
     past = timezone.now() - timedelta(hours=1)
     future = timezone.now() + timedelta(hours=1)
-    published = ArticleFactory(published_from=past)
+    published_no_lang = ArticleFactory(published_from=past, language="")
+    published_fi = ArticleFactory(published_from=past, language="fi")
+    published_en = ArticleFactory(published_from=past, language="en")
     draft_1 = ArticleFactory(published_from=None)
     draft_2 = ArticleFactory(published_from=future)
     draft_3 = ArticleFactory(published_until=past)
 
     public = Article.objects.public()
-    assert published in public
+    assert published_no_lang in public
+    assert published_fi in public
+    assert published_en in public
     assert draft_1 not in public
     assert draft_2 not in public
     assert draft_3 not in public
+
+    public = Article.objects.public(language="en")
+    assert published_fi not in public
+    assert published_en in public
+    assert published_no_lang in public
 
 
 @pytest.mark.django_db

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -63,6 +63,21 @@ def test_article_list_view_tag_filtering(settings, client):
 
 @pytest.mark.urls("cmsplugin_articles_ai.article_urls")
 @pytest.mark.django_db
+def test_article_list_view_lang_filtering(settings, client):
+    """
+    Test article list view can be filtered by passing lang as url parameter.
+    """
+    article_en = PublicArticleFactory(language="en")
+    article_fi = PublicArticleFactory(language="fi")
+
+    url = "%s?lang=en" % reverse("articles")
+    response = client.get(url)
+    assert article_en in response.context["articles"]
+    assert article_fi not in response.context["articles"]
+
+
+@pytest.mark.urls("cmsplugin_articles_ai.article_urls")
+@pytest.mark.django_db
 def test_tag_filtered_article_list_view(admin_client):
     """
     Test tag filtered article view accepts tags and filter mode


### PR DESCRIPTION
Articles now have a required language field that describes the
language used in the article.

In article listings the list can be filtered with language optional
language parameter. CMS plugins also have a language filter field so
that you can either filter the listing with specific language or have
a language agnostic listing.
