### PR TITLE
Fix problem in ArticleView queryset

### DIFF
--- a/cmsplugin_articles_ai/views.py
+++ b/cmsplugin_articles_ai/views.py
@@ -14,7 +14,9 @@ class ArticleView(DetailView):
     """
     model = Article
     template_name = "cmsplugin_articles_ai/article_detail.html"
-    queryset = Article.objects.public()
+
+    def get_queryset(self):
+        return Article.objects.public()
 
     def get_context_data(self, **kwargs):
         context = super(ArticleView, self).get_context_data(**kwargs)


### PR DESCRIPTION
Since ArticleView queryset is time sensitive it can't be defined as
static property.
