### PR TITLE
Pin Django-CMS version to <3.5

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
     long_description=open('README.md').read(),
     description='Articles management app for Django CMS',
     install_requires=[
-        'django-cms>=3.2,<3.4',
+        'django-cms>=3.2,<3.5',
         'django-enumfields>=0.8.0',
         'django-filer>=1.2.4',
         'django-soft-choice-fields>=0.3.1',

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -2,6 +2,7 @@
 import pytest
 from cms.api import add_plugin
 from cms.models import Placeholder
+from cms.plugin_rendering import ContentRenderer
 from cmsplugin_articles_ai.cms_plugins import ArticleList, TagFilterArticleList, TagList
 from cmsplugin_articles_ai.factories import PublicArticleFactory, TagFactory
 
@@ -9,6 +10,14 @@ from cmsplugin_articles_ai.factories import PublicArticleFactory, TagFactory
 def create_articles(amount):
     for _ in range(amount):
         PublicArticleFactory()
+
+
+def init_content_renderer(request=None):
+    """
+    Create and return `ContentRenderer` instance initiated with request.
+    Request may be `None` in some cases.
+    """
+    return ContentRenderer(request)
 
 
 def init_plugin(plugin_type, lang="en", **plugin_data):
@@ -65,7 +74,8 @@ def test_article_list_plugin_html():
     """
     plugin = init_plugin(ArticleList)
     article = PublicArticleFactory()
-    html = plugin.render_plugin({})
+    renderer = init_content_renderer()
+    html = renderer.render_plugin(instance=plugin, context={}, placeholder=plugin.placeholder)
     assert article.title in html
 
 
@@ -80,7 +90,8 @@ def test_tag_article_list_plugin_html():
     article = PublicArticleFactory(tags=[tag])
     plugin = init_plugin(TagFilterArticleList)
     plugin.tags.add(tag)
-    html = plugin.render_plugin({})
+    renderer = init_content_renderer()
+    html = renderer.render_plugin(instance=plugin, context={}, placeholder=plugin.placeholder)
     assert article.title in html
 
 
@@ -93,5 +104,6 @@ def test_tag_list_plugin_html():
     """
     plugin = init_plugin(TagList)
     tag = TagFactory()
-    html = plugin.render_plugin({})
+    renderer = init_content_renderer()
+    html = renderer.render_plugin(instance=plugin, context={}, placeholder=plugin.placeholder)
     assert tag.name in html


### PR DESCRIPTION
Support django-cms 3.4

Update plugin rendering tests because `plugin.render_plugin()` didn't work anymore. The issue was with tests since all plugin types worked fine when monkey testing with simple test project.