### PR TITLE
Add support for publisher workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,10 +9,24 @@ This CMS app provides a way to manage articles. You need to implement the fronte
 1. Install with pip: `pip install cmsplugin-articles-ai`
     - Note that if you want to use factories and management for generating test data, you need to install optional requirements too. You can do that either by manually
     installing them by running `pip install cmsplugin-articles-ai[utils]`
-2. Add `'cmsplugin_articles_ai'` to `INSTALLED_APPS`
-3. Implement frontend
+2. Add `'cmsplugin_articles_ai'` and `'publisher'` to `INSTALLED_APPS`
+3. Add `'publisher.middleware.PublisherMiddleware'` to `MIDDLEWARE_CLASSES`
+4. Implement frontend
     - This package includes only reference templates in (`templates/cmsplugin-articles-ai/`).
     - This package does not include any styling.
+
+## Usage
+
+You will see additional publish workflow buttons in the article edit page.
+Article needs to be saved before you can preview the changes by clicking "Preview Draft" button
+in the top bar. You need to be logged in as staff user and have edit mode on when previewing the changes.
+If you are happy with the changes, go to the article edit page and click "Publish Draft" button.
+Changes will be visible to anonymous users only after publishing the draft.
+
+If you are updating existing project which has articles in the database already, you can use
+`python manage.py publish_model cmsplugin_articles_ai.models.Article` command to generate
+published versions for all of them. Without a published version, article is not visible
+to anonymous users!
 
 ## Installing for development
 

--- a/cmsplugin_articles_ai/admin.py
+++ b/cmsplugin_articles_ai/admin.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
-from cms.admin.placeholderadmin import PlaceholderAdminMixin
 from django.contrib import admin
+from publisher.admin import PublisherAdmin, PublisherPublishedFilter
 
 from .models import Article, ArticleAttachment, Tag
 
@@ -18,7 +18,7 @@ class ArticleAttachmentInline(admin.StackedInline):
     fields = ["name", "attachment_file"]
 
 
-class ArticleAdmin(PlaceholderAdminMixin, admin.ModelAdmin):
+class ArticleAdmin(PublisherAdmin):
     list_display = (
         "title",
         "slug",
@@ -26,12 +26,14 @@ class ArticleAdmin(PlaceholderAdminMixin, admin.ModelAdmin):
         "author",
         "published_from",
         "published_until",
+        'publisher_publish',
+        'publisher_status'
     )
     prepopulated_fields = {
         "slug": ("title",),
     }
     filter_horizontal = ["tags"]
-    list_filter = ["language", "tags"]
+    list_filter = ["language", "tags", PublisherPublishedFilter]
     inlines = [ArticleAttachmentInline]
 
     def get_form(self, request, obj=None, **kwargs):

--- a/cmsplugin_articles_ai/cms_plugins.py
+++ b/cmsplugin_articles_ai/cms_plugins.py
@@ -3,6 +3,7 @@ from cms.models import CMSPlugin
 from cms.plugin_base import CMSPluginBase
 from cms.plugin_pool import plugin_pool
 from django.utils.translation import ugettext_lazy as _
+from publisher.middleware import get_draft_status
 
 from .models import Article, ArticleListPlugin, Tag
 
@@ -17,7 +18,7 @@ class ArticleList(CMSPluginBase):
     def get_articles(self, plugin_conf):
         return Article.objects.public(
             language=plugin_conf.language_filter,
-        )
+        ).filter(publisher_is_draft=get_draft_status())
 
     def render(self, context, instance, placeholder):
         context.update({

--- a/cmsplugin_articles_ai/migrations/0006_add_publisher_support.py
+++ b/cmsplugin_articles_ai/migrations/0006_add_publisher_support.py
@@ -1,0 +1,36 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+import django.db.models.deletion
+import django.utils.timezone
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('cmsplugin_articles_ai', '0005_make_tag_slug_field_unique'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='article',
+            name='publisher_is_draft',
+            field=models.BooleanField(default=True, editable=False, db_index=True),
+        ),
+        migrations.AddField(
+            model_name='article',
+            name='publisher_linked',
+            field=models.OneToOneField(null=True, related_name='publisher_draft', to='cmsplugin_articles_ai.Article', on_delete=django.db.models.deletion.SET_NULL, editable=False),
+        ),
+        migrations.AddField(
+            model_name='article',
+            name='publisher_modified_at',
+            field=models.DateTimeField(default=django.utils.timezone.now, editable=False),
+        ),
+        migrations.AddField(
+            model_name='article',
+            name='publisher_published_at',
+            field=models.DateTimeField(null=True, editable=False),
+        ),
+    ]

--- a/cmsplugin_articles_ai/views.py
+++ b/cmsplugin_articles_ai/views.py
@@ -1,14 +1,13 @@
 # -*- coding: utf-8 -*-
-import json
 
 from django.conf import settings
 from django.utils.translation import ugettext_lazy as _
-from django.views.generic import DetailView, ListView
+from publisher.views import PublisherDetailView, PublisherListView
 
 from .models import Article, Tag, TagFilterMode
 
 
-class ArticleView(DetailView):
+class ArticleView(PublisherDetailView):
     """
     View for displaying single article.
     """
@@ -16,7 +15,8 @@ class ArticleView(DetailView):
     template_name = "cmsplugin_articles_ai/article_detail.html"
 
     def get_queryset(self):
-        return Article.objects.public()
+        articles = super(ArticleView, self).get_queryset()
+        return articles.public()
 
     def get_context_data(self, **kwargs):
         context = super(ArticleView, self).get_context_data(**kwargs)
@@ -36,13 +36,14 @@ class ArticleView(DetailView):
         return context
 
 
-class ArticleListView(ListView):
+class ArticleListView(PublisherListView):
     """
     View for listing all public articles or a list of public articles
     per tag. By default the list is language agnostic, but you can pass
     optional language parameter to get a filtered list.
     Lists are paginated according to settings value.
     """
+    model = Article
     context_object_name = "articles"
     paginate_by = getattr(settings, "ARTICLES_PER_PAGE", 10)
     tag_filter = ""
@@ -54,7 +55,8 @@ class ArticleListView(ListView):
         return super(ArticleListView, self).get(request, *args, **kwargs)
 
     def get_queryset(self):
-        articles = Article.objects.public(language=self.lang_filter)
+        articles = super(ArticleListView, self).get_queryset()
+        articles = articles.public(language=self.lang_filter)
         if self.tag_filter:
             return articles.filter(tags__slug=self.tag_filter)
         return articles

--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,7 @@ setup(
         'django-soft-choice-fields>=0.3.1',
         'djangocms_text_ckeditor>=3.0.0',
         'easy-thumbnails>=2.3',
+        'django-model-publisher-ai>=0.3.1',
     ],
     extras_require=({
         'utils': ['factory-boy>=0.6.0'],

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -1,16 +1,19 @@
 # -*- coding: utf-8 -*-
 import pytest
-from cms.api import add_plugin
-from cms.models import Placeholder
-from cmsplugin_articles_ai.cms_plugins import ArticleList
+
 from cmsplugin_articles_ai.factories import NotPublicArticleFactory, PublicArticleFactory, TagFactory
-from cmsplugin_articles_ai.models import Tag, TagFilterMode
+from cmsplugin_articles_ai.models import Article, Tag, TagFilterMode
 from django.core.urlresolvers import reverse
 
 
 def create_articles(amount):
     for _ in range(amount):
         PublicArticleFactory()
+
+
+def publish_articles_with_publisher(articles):
+    for article in articles:
+        article.publish()
 
 
 @pytest.mark.urls("cmsplugin_articles_ai.article_urls")
@@ -24,11 +27,14 @@ def test_article_detail_view(client, article_factory, status_code):
     Test article list view lists paginated list of articles.
     """
     article = article_factory()
+    article.publish()
+
     url = reverse("article", kwargs={"slug": article.slug})
     response = client.get(url)
     assert response.status_code == status_code
     if status_code == 200:
-        assert response.context["article"].pk == article.pk
+        published_article = Article.publisher_manager.published().first()
+        assert response.context["article"].pk == published_article.pk
 
 
 @pytest.mark.urls("cmsplugin_articles_ai.article_urls")
@@ -38,6 +44,8 @@ def test_article_list_view_pagination(settings, client):
     Test article list view lists paginated list of articles.
     """
     create_articles(10)
+    publish_articles_with_publisher(Article.objects.all())
+
     url = reverse("articles")
     response = client.get(url)
     assert len(response.context["articles"]) == settings.ARTICLES_PER_PAGE
@@ -52,12 +60,15 @@ def test_article_list_view_tag_filtering(settings, client):
     news = TagFactory(name="news")
     home_office = TagFactory(name="home office")
     PublicArticleFactory(tags=[news])
-    office_article = PublicArticleFactory(tags=[home_office])
+    PublicArticleFactory(title="office_article", tags=[home_office])
+
+    publish_articles_with_publisher(Article.objects.all())
 
     url = reverse("tagged_articles", kwargs={"tag": home_office.slug})
     response = client.get(url)
+    published_office_article = Article.publisher_manager.published().get(title="office_article")
     assert len(response.context["articles"]) == 1
-    assert response.context["articles"][0].pk == office_article.pk
+    assert response.context["articles"][0].pk == published_office_article.pk
 
 
 @pytest.mark.urls("cmsplugin_articles_ai.article_urls")
@@ -66,13 +77,17 @@ def test_article_list_view_lang_filtering(settings, client):
     """
     Test article list view can be filtered by passing lang as url parameter.
     """
-    article_en = PublicArticleFactory(language="en")
-    article_fi = PublicArticleFactory(language="fi")
+    PublicArticleFactory(language="en")
+    PublicArticleFactory(language="fi")
+
+    publish_articles_with_publisher(Article.objects.all())
 
     url = "%s?lang=en" % reverse("articles")
     response = client.get(url)
-    assert article_en in response.context["articles"]
-    assert article_fi not in response.context["articles"]
+    published_article_en = Article.publisher_manager.published().get(language="en")
+    published_article_fi = Article.publisher_manager.published().get(language="fi")
+    assert published_article_en in response.context["articles"]
+    assert published_article_fi not in response.context["articles"]
 
 
 @pytest.mark.urls("cmsplugin_articles_ai.article_urls")
@@ -86,8 +101,12 @@ def test_tag_filtered_article_list_view(admin_client):
     office = TagFactory(name="office")
     tech = TagFactory(name="tech")
     feedback = TagFactory(name="feedback")
-    article1 = PublicArticleFactory(tags=[news, office])
-    article2 = PublicArticleFactory(tags=[tech])
+    PublicArticleFactory(title="article1", tags=[news, office])
+    PublicArticleFactory(title="article2", tags=[tech])
+
+    publish_articles_with_publisher(Article.objects.all())
+    published_article1 = Article.publisher_manager.published().get(title="article1")
+    published_article2 = Article.publisher_manager.published().get(title="article2")
 
     # Test ANY filter mode with news and feedback tags
     url = "%s?%s&%s" % (
@@ -97,8 +116,8 @@ def test_tag_filtered_article_list_view(admin_client):
     )
     response = admin_client.get(url)
     articles = response.context["articles"]
-    assert article1 in articles
-    assert article2 not in articles
+    assert published_article1 in articles
+    assert published_article2 not in articles
 
     # Test ALL filter mode with news and office tags
     url = "%s?%s&%s" % (
@@ -108,5 +127,5 @@ def test_tag_filtered_article_list_view(admin_client):
     )
     response = admin_client.get(url)
     articles = response.context["articles"]
-    assert article1 in articles
-    assert article2 not in articles
+    assert published_article1 in articles
+    assert published_article2 not in articles


### PR DESCRIPTION
Add django-model-publisher to requirements and use the module
to add functionality to preview changes made to the articles
before publishing them to visitors. Add instructions to README
file. Update tests to work with publisher functionality.