### PR TITLE
Add lead paragraph to article model

### DIFF
--- a/cmsplugin_articles_ai/migrations/0007_add_lead_paragraph_and_permissions.py
+++ b/cmsplugin_articles_ai/migrations/0007_add_lead_paragraph_and_permissions.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+import djangocms_text_ckeditor.fields
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('cmsplugin_articles_ai', '0006_add_publisher_support'),
+    ]
+
+    operations = [
+        migrations.AlterModelOptions(
+            name='article',
+            options={'permissions': (('can_publish', 'Can publish'),), 'verbose_name_plural': 'articles', 'ordering': ('-published_from', '-pk'), 'verbose_name': 'article'},
+        ),
+        migrations.AddField(
+            model_name='article',
+            name='lead_paragraph',
+            field=djangocms_text_ckeditor.fields.HTMLField(blank=True, verbose_name='lead paragraph'),
+        ),
+    ]

--- a/cmsplugin_articles_ai/models/articles.py
+++ b/cmsplugin_articles_ai/models/articles.py
@@ -145,8 +145,8 @@ class Article(PublisherModel):
         blank=True,
         on_delete=models.SET_NULL,
     )
+    lead_paragraph = HTMLField(verbose_name=_("lead paragraph"), blank=True)
     main_content = HTMLField(verbose_name=_("content"))
-
     created_at = models.DateTimeField(
         _("creation time"), auto_now_add=True, editable=False,
     )
@@ -156,7 +156,7 @@ class Article(PublisherModel):
 
     objects = ArticleQuerySet.as_manager()
 
-    class Meta:
+    class Meta(PublisherModel.Meta):
         verbose_name = _("article")
         verbose_name_plural = _("articles")
         ordering = ('-published_from', '-pk')


### PR DESCRIPTION
Add lead paragraph HTMLfield to article model. Also inherit
Article's Meta class from PublisherModel.Meta which gives
custom can_publish permission for article model. This permission
is required if user is not superuser and needs to be able to
use publisher workflow buttons in article admin.