### PR TITLE
Add option to not list article on widgets

### DIFF
--- a/cmsplugin_articles_ai/cms_plugins.py
+++ b/cmsplugin_articles_ai/cms_plugins.py
@@ -18,7 +18,10 @@ class ArticleList(CMSPluginBase):
     def get_articles(self, plugin_conf):
         return Article.objects.public(
             language=plugin_conf.language_filter,
-        ).filter(publisher_is_draft=get_draft_status())
+        ).filter(
+            publisher_is_draft=get_draft_status(),
+            show_in_article_list_plugin=True,
+        )
 
     def render(self, context, instance, placeholder):
         context.update({

--- a/cmsplugin_articles_ai/migrations/0009_article_show_in_article_list_plugin.py
+++ b/cmsplugin_articles_ai/migrations/0009_article_show_in_article_list_plugin.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('cmsplugin_articles_ai', '0008_categories'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='article',
+            name='show_in_article_list_plugin',
+            field=models.BooleanField(default=True, verbose_name='show in article list plugin'),
+        ),
+    ]

--- a/cmsplugin_articles_ai/models/articles.py
+++ b/cmsplugin_articles_ai/models/articles.py
@@ -161,6 +161,10 @@ class Article(PublisherModel):
     modified_at = models.DateTimeField(
         _("last modified"), auto_now=True, editable=False,
     )
+    show_in_article_list_plugin = models.BooleanField(
+        verbose_name=_("show in article list plugin"),
+        default=True,
+    )
 
     objects = ArticleQuerySet.as_manager()
 

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -47,6 +47,23 @@ def test_article_list_plugin_article_count():
 
 
 @pytest.mark.django_db
+def test_article_list_plugin_show_flag():
+    """
+    Test article list plugin showing only the articles with the
+    show_in_article_list_plugin flag set to True
+    """
+    create_articles(3)
+    hidden_article = Article.objects.get(pk=3)
+    hidden_article.show_in_article_list_plugin = False
+    hidden_article.save()
+    publish_articles_with_publisher(Article.objects.all())
+    plugin = init_plugin(ArticleList, article_amount=3)
+    plugin_instance = plugin.get_plugin_class_instance()
+    context = plugin_instance.render({}, plugin, None)
+    assert len(context["articles"]) == 2
+
+
+@pytest.mark.django_db
 @pytest.mark.parametrize("language_filter", ["", "en", "fi"])
 def test_article_list_plugin_language_filter(language_filter):
     """


### PR DESCRIPTION
Add the possibility to not list an article on the article widgets
This is done by adding a boolean field/checkbox to the article model

Refs [SER-3446](https://project.anders.fi/browse/SER-3446)