### PR TITLE
Fix article list exlusion filters not publishing

### DIFF
--- a/cmsplugin_articles_ai/models/plugin_models.py
+++ b/cmsplugin_articles_ai/models/plugin_models.py
@@ -86,3 +86,5 @@ class ArticleListPlugin(CMSPlugin):
         # version of this object.
         # Docs: http://docs.django-cms.org/en/latest/how_to/custom_plugins.html#for-many-to-many-or-foreign-key-relations-to-other-objects  # NOQA
         self.tags = oldinstance.tags.all()
+        self.exclude_categories = oldinstance.exclude_categories.all()
+        self.exclude_tags = oldinstance.exclude_tags.all()


### PR DESCRIPTION
Article List plugin's exclusion filters are not published due to copy relations not being implemented
Fix this issue by implementing copy relations properly

No refs